### PR TITLE
To avoid security issues with the pypi package, we'll run pypi deployments manually.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ python:
 - '3.4'
 install: pip install -r requirements.txt
 script: nosetests
-deploy:
-  provider: pypi
-  user: mrhwick
-  password:
-    secure: TuBmssgOKlKL+kF1lE+eZhe2uo3v8/sc7+/xTBzXN3OgXWLa1HYmkye1cBKAQhUDgk2hOQLfGzRpH58Vmug0IXZxHzx87JRIKiGHuXvCrcctrV8Q4Ie3QzcA1xx6bmZyF3WJWH427wRQrpMtSTedRblbTBIJBm83JpUFKeNA7Pc=
-  on:
-    tags: true
+cache:
+  directories:
+  - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
+  - /home/travis/virtualenv/python3.2/lib/python3.2/site-packages
+  - /home/travis/virtualenv/python3.3/lib/python3.3/site-packages
+  - /home/travis/virtualenv/python3.4/lib/python3.4/site-packages


### PR DESCRIPTION
## Purpose

There are workflows that would enable attackers to deploy bogus packages to our pypi using travis-ci if we use the travis-ci pypi deployment strategy, even when the credentials are encrypted. Rather than risking the usage of these workflows, we will instead deploy pypi deployments manually.
